### PR TITLE
Migrate to unified setup-lecture-env-full action

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,21 +11,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       
-      # Use composite action for environment setup
-      - name: Setup Lecture Environment
-        uses: quantecon/actions/setup-lecture-env@main
+      # Use unified composite action for complete environment setup
+      - name: Setup Complete Lecture Environment
+        uses: quantecon/actions/setup-lecture-env-full@main
         with:
           python-version: '3.13'
           environment-file: 'environment.yml'
+          latex-requirements-file: 'latex-requirements.txt'
           environment-name: 'quantecon'
       
       - name: graphviz Support # TODO: required?
         run: |
           sudo apt-get -qq update && sudo apt-get install -y graphviz
-      
-      # Use composite action for LaTeX setup
-      - name: Install LaTeX Dependencies
-        uses: quantecon/actions/setup-latex@main
       
       # Use composite action for building
       - name: Build HTML


### PR DESCRIPTION
This PR migrates cache.yml to use the new unified `setup-lecture-env-full` composite action.

## Changes
- Replaces separate `setup-lecture-env` and `setup-latex` actions with unified `setup-lecture-env-full`
- Simplifies workflow configuration (one action instead of two)
- Provides optimized caching for both Conda and LaTeX packages

## Benefits
- **Conda cache**: Saves ~5-6 minutes (full environment)
- **LaTeX apt cache**: Saves ~1-2 minutes (download time)
- **Total savings**: ~6-8 minutes with both caches hit vs ~12 min fresh

## Testing
This PR will rebuild the global caches on main using the new unified action.

Related to PR #4 (ci-migration) which uses the same unified action for CI workflows.