### PR TITLE
fix: remove environment.yml push trigger from cache workflow

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,9 +1,5 @@
 name: Build Cache
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'environment.yml'
   schedule:
     - cron: '0 3 * * 0'  # Weekly Sunday 3am
   workflow_dispatch:


### PR DESCRIPTION
In container mode, `environment.yml` has no effect on the build — the container's pre-installed environment is used. Removes the unnecessary push trigger so `environment.yml` changes don't cause cache rebuilds. The weekly schedule (Sunday 3am UTC) and manual dispatch remain.