### PR TITLE
feat: build PDF and notebooks in CI preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,28 @@ jobs:
           cache-type: 'build'
           source-dir: 'lectures'
       
+      - name: Build PDF
+        uses: quantecon/actions/build-lectures@v0.5.0
+        with:
+          source-dir: 'lectures'
+          builder: 'pdflatex'
+          upload-failure-reports: true
+      
+      - name: Build Notebooks
+        uses: quantecon/actions/build-lectures@v0.5.0
+        with:
+          source-dir: 'lectures'
+          builder: 'jupyter'
+          upload-failure-reports: true
+      
       - name: Build HTML
         id: build
         uses: quantecon/actions/build-lectures@v0.5.0
         with:
           source-dir: 'lectures'
           builder: 'html'
+          html-copy-pdf: true
+          html-copy-notebooks: true
           upload-failure-reports: true
       
       - name: Deploy to Netlify


### PR DESCRIPTION
Add PDF and notebook builds to the CI preview workflow so the Netlify preview includes all asset types (matching the publish workflow).

## Changes

- Add `pdflatex` build step before HTML
- Add `jupyter` (notebook) build step before HTML
- Enable `html-copy-pdf` and `html-copy-notebooks` on the HTML build step
- Builds run sequentially in a single job: PDF → Notebooks → HTML → Netlify deploy

## Notes

- Sequential approach reuses the container, checkout, and execution cache — avoids the overhead of parallel jobs each pulling the container separately
- Depends on the updated `quantecon-build` container (with `texlive-fonts-extra` for PDF builds) — container rebuild is in progress
