### PR TITLE
feat: enable PR-scoped build caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           cache-type: 'build'
           source-dir: 'lectures'
+          save-cache: 'true'
       
       - name: Build HTML
         id: build

--- a/lectures/intro.md
+++ b/lectures/intro.md
@@ -11,7 +11,7 @@ kernelspec:
 
 # (TEST) A First Course in Quantitative Economics with Python
 
-This lecture series provides an introduction to quantitative economics using Python. 
+This lecture series provides an introduction to quantitative economics using Python.
 
 ```{tableofcontents}
 ```


### PR DESCRIPTION
Enable PR-scoped build caching so subsequent pushes to the same PR are faster.

## Change

Add `save-cache: 'true'` to the `restore-jupyter-cache` step in CI.

## How it works

1. **First PR run**: Restores weekly cache from main → full build → saves result as PR-scoped cache
2. **Second+ PR runs**: Restores the PR's own cache → only re-executes changed notebooks → saves updated cache

Cache is automatically scoped to this PR branch by GitHub Actions — no risk of affecting other PRs or main.

## Test plan

- This PR's first CI run should complete normally and save a cache
- Push a trivial commit to this PR — second run should restore the PR cache and be significantly faster
