### PR TITLE
⬆️ Update quantecon/actions to v0.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+# GitHub Copilot Instructions
+
+## GitHub CLI (gh) Usage
+
+**Important:** Shell escaping in zsh doesn't work reliably when passing multi-line strings or complex text directly to `gh` commands. Always write PR/issue descriptions to a temporary file first, then reference the file.
+
+### Best Practice
+
+Instead of:
+```bash
+gh pr create --title "Title" --body "Multi-line
+description with special characters"
+```
+
+Do this:
+```bash
+# Write description to temporary file
+cat > .tmp/pr-description.md << 'EOF'
+Multi-line description
+with special characters
+EOF
+
+# Use the file
+gh pr create --title "Title" --body-file .tmp/pr-description.md
+```
+
+### Temporary Files
+
+- Use `.tmp/` directory for temporary files (e.g., PR descriptions, issue bodies)
+- This directory is gitignored and safe for temporary content
+- Clean up files after use if needed, or leave them for debugging

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Build and Cache
-        uses: quantecon/actions/build-jupyter-cache@v0
+        uses: quantecon/actions/build-jupyter-cache@v0.6.0
         with:
           builders: 'html'
           source-dir: 'lectures'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,21 +20,21 @@ jobs:
       
       - name: Restore Build Cache
         id: cache
-        uses: quantecon/actions/restore-jupyter-cache@v0
+        uses: quantecon/actions/restore-jupyter-cache@v0.6.0
         with:
           cache-type: 'build'
           source-dir: 'lectures'
           save-cache: 'true'
       
       - name: Build PDF
-        uses: quantecon/actions/build-lectures@v0.5.0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'pdflatex'
           upload-failure-reports: true
       
       - name: Build Notebooks
-        uses: quantecon/actions/build-lectures@v0.5.0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'jupyter'
@@ -42,7 +42,7 @@ jobs:
       
       - name: Build HTML
         id: build
-        uses: quantecon/actions/build-lectures@v0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'html'
@@ -51,7 +51,7 @@ jobs:
           upload-failure-reports: true
       
       - name: Deploy to Netlify
-        uses: quantecon/actions/preview-netlify@v0
+        uses: quantecon/actions/preview-netlify@v0.6.0
         with:
           build-dir: ${{ steps.build.outputs.build-path }}
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,14 +28,14 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Build PDF
-        uses: quantecon/actions/build-lectures@v0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'pdflatex'
           upload-failure-reports: true
       
       - name: Build Notebooks
-        uses: quantecon/actions/build-lectures@v0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'jupyter'
@@ -43,7 +43,7 @@ jobs:
       
       - name: Build HTML
         id: build
-        uses: quantecon/actions/build-lectures@v0
+        uses: quantecon/actions/build-lectures@v0.6.0
         with:
           source-dir: 'lectures'
           builder: 'html'
@@ -53,6 +53,6 @@ jobs:
       
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: quantecon/actions/publish-gh-pages@v0
+        uses: quantecon/actions/publish-gh-pages@v0.6.0
         with:
           build-dir: ${{ steps.build.outputs.build-path }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lectures/_build
 .ipynb_checkpoints/
 .virtual_documents/
 _build/*
+.tmp/


### PR DESCRIPTION
## Summary
This PR updates all `quantecon/actions` references in GitHub Actions workflows to use the pinned version `v0.6.0`.

## Changes
- **ci.yml**: Updated 5 action references from `@v0` and `@v0.5.0` to `@v0.6.0`
- **publish.yml**: Updated 4 action references from `@v0` to `@v0.6.0`
- **cache.yml**: Updated 1 action reference from `@v0` to `@v0.6.0`

## Benefits
- **Dependabot compatibility**: Pinned versions allow Dependabot to automatically create PRs for future updates
- **Build reproducibility**: Explicit version pinning ensures consistent builds
- **Version control**: Clear tracking of which action versions are in use

## Actions updated
- `quantecon/actions/restore-jupyter-cache`
- `quantecon/actions/build-lectures`
- `quantecon/actions/preview-netlify`
- `quantecon/actions/publish-gh-pages`
- `quantecon/actions/build-jupyter-cache`
